### PR TITLE
Add support for proxying IList<>

### DIFF
--- a/src/Microsoft.Framework.Notification/Internal/ProxyAssembly.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyAssembly.cs
@@ -20,8 +20,13 @@ namespace Microsoft.Framework.Notification.Internal
         {
             var assemblyName = new AssemblyName("Microsoft.Framework.Notification.ProxyAssembly");
 
-            AssemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
-            ModuleBuilder = AssemblyBuilder.DefineDynamicModule("Main Module");
+#if NET45 || DNX451
+            var access = AssemblyBuilderAccess.RunAndSave;
+#else
+            var access = AssemblyBuilderAccess.Run;
+#endif
+            AssemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, access);
+            ModuleBuilder = AssemblyBuilder.DefineDynamicModule("Microsoft.Framework.Notification.ProxyAssembly.dll");
         }
 
         public static TypeBuilder DefineType(
@@ -33,6 +38,16 @@ namespace Microsoft.Framework.Notification.Internal
             name = name + "_" + Counter++;
             return ModuleBuilder.DefineType(name, attributes, baseType, interfaces);
         }
+
+#if NET45 || DNX451
+
+        public static void WriteToFile(string file)
+        {
+            AssemblyBuilder.Save(file);
+        }
+
+#endif
+
     }
 }
 

--- a/src/Microsoft.Framework.Notification/Internal/ProxyEnumerable.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyEnumerable.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET45 || DNX451 || DNXCORE50
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Microsoft.Framework.Notification.Internal
+{
+    public class ProxyEnumerable<TSourceElement, TTargetElement> : IEnumerable<TTargetElement>
+    {
+        private readonly IEnumerable<TSourceElement> _source;
+        private readonly Type _proxyType;
+
+        public ProxyEnumerable(IEnumerable<TSourceElement> source, Type proxyType)
+        {
+            _source = source;
+            _proxyType = proxyType;
+        }
+
+        public IEnumerator<TTargetElement> GetEnumerator()
+        {
+            return new ProxyEnumerator(_source.GetEnumerator(), _proxyType);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        public class ProxyEnumerator : IEnumerator<TTargetElement>
+        {
+            private readonly IEnumerator<TSourceElement> _source;
+            private readonly Type _proxyType;
+
+            public ProxyEnumerator(IEnumerator<TSourceElement> source, Type proxyType)
+            {
+                _source = source;
+
+                _proxyType = proxyType;
+            }
+
+            public TTargetElement Current
+            {
+                get
+                {
+                    var element = _source.Current;
+                    return MakeProxy(element);
+                }
+            }
+
+            object IEnumerator.Current
+            {
+                get
+                {
+                    return Current;
+                }
+            }
+
+            public void Dispose()
+            {
+                _source.Dispose();
+            }
+
+            public bool MoveNext()
+            {
+                return _source.MoveNext();
+            }
+
+            public void Reset()
+            {
+                _source.Reset();
+            }
+
+            private TTargetElement MakeProxy(TSourceElement element)
+            {
+                if (_proxyType == null)
+                {
+                    return (TTargetElement)(object)element;
+                }
+                else
+                {
+                    return (TTargetElement)Activator.CreateInstance(
+                        _proxyType,
+                        new object[] { element });
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/src/Microsoft.Framework.Notification/Internal/ProxyList.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyList.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+#if NET45 || DNX451 || DNXCORE50
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.Framework.Internal;
+
+namespace Microsoft.Framework.Notification.Internal
+{
+    public class ProxyList<TSourceElement, TTargetElement> : IReadOnlyList<TTargetElement>
+    {
+        private readonly IList<TSourceElement> _source;
+        private readonly Type _proxyType;
+
+        public ProxyList([NotNull] IList<TSourceElement> source)
+            : this(source, null)
+        {
+        }
+
+        protected ProxyList([NotNull] IList<TSourceElement> source, Type proxyType)
+        {
+            _source = source;
+            _proxyType = proxyType;
+        }
+
+        public TTargetElement this[int index]
+        {
+            get
+            {
+                var element = _source[index];
+                return MakeProxy(element);
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                return _source.Count;
+            }
+        }
+
+        public IEnumerator<TTargetElement> GetEnumerator()
+        {
+            return new ProxyEnumerable<TSourceElement, TTargetElement>.ProxyEnumerator(_source.GetEnumerator(), _proxyType);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        private TTargetElement MakeProxy(TSourceElement element)
+        {
+            if (_proxyType == null)
+            {
+                return (TTargetElement)(object)element;
+            }
+            else
+            {
+                return (TTargetElement)Activator.CreateInstance(
+                    _proxyType,
+                    new object[] { element });
+            }
+        }
+    }
+}
+
+#endif

--- a/src/Microsoft.Framework.Notification/Internal/ProxyTypeCacheResult.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyTypeCacheResult.cs
@@ -4,7 +4,7 @@
 #if NET45 || DNX451 || DNXCORE50
 
 using System;
-using System.Reflection.Emit;
+using System.Reflection;
 
 namespace Microsoft.Framework.Notification.Internal
 {
@@ -19,20 +19,20 @@ namespace Microsoft.Framework.Notification.Internal
             };
         }
 
-        public static ProxyTypeCacheResult FromTypeBuilder(
+        public static ProxyTypeCacheResult FromType(
             Tuple<Type, Type> key,
-            TypeBuilder typeBuilder,
-            ConstructorBuilder constructorBuilder)
+            Type type,
+            ConstructorInfo constructor)
         {
             return new ProxyTypeCacheResult()
             {
                 Key = key,
-                TypeBuilder = typeBuilder,
-                ConstructorBuilder = constructorBuilder,
+                Type = type,
+                Constructor = constructor,
             };
         }
 
-        public ConstructorBuilder ConstructorBuilder { get; private set; }
+        public ConstructorInfo Constructor { get; private set; }
 
         public string Error { get; private set; }
 
@@ -40,7 +40,7 @@ namespace Microsoft.Framework.Notification.Internal
 
         public Tuple<Type, Type> Key { get; private set; }
 
-        public TypeBuilder TypeBuilder { get; private set; }
+        public Type Type { get; private set; }
     }
 }
 #endif

--- a/test/Microsoft.Framework.Notification.Test/Internal/ProxyTypeEmitterTest.cs
+++ b/test/Microsoft.Framework.Notification.Test/Internal/ProxyTypeEmitterTest.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Framework.Notification.Internal
@@ -210,6 +212,306 @@ namespace Microsoft.Framework.Notification.Internal
             Assert.Equal(expected, exception.Message);
         }
 
+        [Fact]
+        public void Adapt_List_ToReadOnlyList()
+        {
+            // Arrange
+            var value = new List<string>()
+            {
+                "Hello",
+                "World",
+            };
+
+            // Act 
+            var proxy = Convert<IList<string>, IReadOnlyList<string>>(value);
+
+            // Assert
+            Assert.NotNull(proxy);
+            Assert.Equal(2, proxy.Count);
+            Assert.Equal("Hello", proxy[0]);
+            Assert.Equal("World", proxy[1]);
+        }
+
+        [Fact]
+        public void Adapt_List_ToReadOnlyList_Enumerator()
+        {
+            // Arrange
+            var value = new List<string>()
+            {
+                "Hello",
+                "World",
+            };
+
+            // Act 
+            var proxy = Convert<IList<string>, IReadOnlyList<string>>(value);
+
+            // Assert
+            Assert.NotNull(proxy);
+
+            var sequence = value.Zip(proxy, (i, j) => Tuple.Create(i, j));
+            foreach (var item in sequence)
+            {
+                Assert.Equal(item.Item1, item.Item2);
+            }
+        }
+
+        [Fact]
+        public void Adapt_ListWithProxy_ToReadOnlyList()
+        {
+            // Arrange
+            var value = new List<Person>()
+            {
+                new Person() { FirstName = "Billy" },
+                new Person() { FirstName = "Joe" },
+            };
+
+            // Act 
+            var proxy = Convert<IList<Person>, IReadOnlyList<IPerson>>(value);
+
+            // Assert
+            Assert.NotNull(proxy);
+            Assert.Equal(2, proxy.Count);
+            Assert.Equal("Billy", proxy[0].FirstName);
+            Assert.Equal("Joe", proxy[1].FirstName);
+        }
+
+        [Fact]
+        public void Adapt_ListWithProxy_ToReadOnlyList_Enumerator()
+        {
+            // Arrange
+            var value = new List<Person>()
+            {
+                new Person() { FirstName = "Billy" },
+                new Person() { FirstName = "Joe" },
+            };
+
+            // Act 
+            var proxy = Convert<IList<Person>, IReadOnlyList<IPerson>>(value);
+
+            // Assert
+            Assert.NotNull(proxy);
+
+            var sequence = value.Zip(proxy, (i, j) => Tuple.Create(i, j));
+            foreach (var item in sequence)
+            {
+                Assert.Equal(item.Item1.FirstName, item.Item2.FirstName);
+            }
+        }
+
+        [Fact]
+        public void Adapt_Array_ToReadOnlyList()
+        {
+            // Arrange
+            var value = new string[]
+            {
+                "Hello",
+                "World",
+            };
+
+            // Act 
+            var proxy = Convert<IList<string>, IReadOnlyList<string>>(value);
+
+            // Assert
+            Assert.NotNull(proxy);
+            Assert.Equal(2, proxy.Count);
+            Assert.Equal("Hello", proxy[0]);
+            Assert.Equal("World", proxy[1]);
+        }
+
+        [Fact]
+        public void Adapt_Array_ToReadOnlyList_Enumerator()
+        {
+            // Arrange
+            var value = new string[]
+            {
+                "Hello",
+                "World",
+            };
+
+            // Act 
+            var proxy = Convert<IList<string>, IReadOnlyList<string>>(value);
+
+            // Assert
+            Assert.NotNull(proxy);
+
+            var sequence = value.Zip(proxy, (i, j) => Tuple.Create(i, j));
+            foreach (var item in sequence)
+            {
+                Assert.Equal(item.Item1, item.Item2);
+            }
+        }
+
+        [Fact]
+        public void Adapt_ListProperty_ToReadOnlyList()
+        {
+            // Arrange
+            var value = new HasListProperty()
+            {
+                ListProperty = new List<string>()
+                {
+                    "Hello",
+                    "World",
+                },
+            };
+
+            // Act 
+            var proxy = ConvertTo<IHasReadOnlyListProperty>(value);
+
+            // Assert
+            Assert.NotNull(proxy.ListProperty);
+            Assert.Equal(2, proxy.ListProperty.Count);
+            Assert.Equal("Hello", proxy.ListProperty[0]);
+            Assert.Equal("World", proxy.ListProperty[1]);
+        }
+
+        [Fact]
+        public void Adapt_ListListProperty_ToReadOnlyList_Enumerator()
+        {
+            // Arrange
+            var value = new HasListProperty()
+            {
+                ListProperty = new List<string>()
+                {
+                    "Hello",
+                    "World",
+                },
+            };
+
+            // Act 
+            var proxy = ConvertTo<IHasReadOnlyListProperty>(value);
+
+            // Assert
+            Assert.NotNull(proxy.ListProperty);
+
+            var sequence = value.ListProperty.Zip(proxy.ListProperty, (i, j) => Tuple.Create(i, j));
+            foreach (var item in sequence)
+            {
+                Assert.Equal(item.Item1, item.Item2);
+            }
+        }
+
+        [Fact]
+        public void Adapt_ArrayListProperty_ToReadOnlyList()
+        {
+            // Arrange
+            var value = new HasArrayProperty()
+            {
+                ListProperty = new string[]
+                {
+                    "Hello",
+                    "World",
+                },
+            };
+
+            // Act 
+            var proxy = ConvertTo<IHasReadOnlyListProperty>(value);
+
+            // Assert
+            Assert.NotNull(proxy.ListProperty);
+            Assert.Equal(2, proxy.ListProperty.Count);
+            Assert.Equal("Hello", proxy.ListProperty[0]);
+            Assert.Equal("World", proxy.ListProperty[1]);
+        }
+
+        [Fact]
+        public void Adapt_ArrayListProperty_ToReadOnlyList_Enumerator()
+        {
+            // Arrange
+            var value = new HasArrayProperty()
+            {
+                ListProperty = new string[]
+                {
+                    "Hello",
+                    "World",
+                },
+            };
+
+            // Act 
+            var proxy = ConvertTo<IHasReadOnlyListProperty>(value);
+
+            // Assert
+            Assert.NotNull(proxy.ListProperty);
+
+            var sequence = value.ListProperty.Zip(proxy.ListProperty, (i, j) => Tuple.Create(i, j));
+            foreach (var item in sequence)
+            {
+                Assert.Equal(item.Item1, item.Item2);
+            }
+        }
+
+        [Fact]
+        public void Adapt_ListPropertyWithProxy_ToReadOnlyList()
+        {
+            // Arrange
+            var value = new HasListOfPersonProperty()
+            {
+                ListProperty = new List<Person>()
+                {
+                    new Person() { FirstName = "Billy" },
+                    new Person() { FirstName = "Joe" },
+                }
+            };
+
+            // Act 
+            var proxy = ConvertTo<IHasReadOnlyListOfPersonProperty>(value);
+
+            // Assert
+            Assert.NotNull(proxy);
+            Assert.Equal(2, proxy.ListProperty.Count);
+            Assert.Equal("Billy", proxy.ListProperty[0].FirstName);
+            Assert.Equal("Joe", proxy.ListProperty[1].FirstName);
+        }
+
+        [Fact]
+        public void Adapt_ListPropertyWithProxy_ToReadOnlyList_Enumerator()
+        {
+            // Arrange
+            var value = new HasListOfPersonProperty()
+            {
+                ListProperty = new List<Person>()
+                {
+                    new Person() { FirstName = "Billy" },
+                    new Person() { FirstName = "Joe" },
+                }
+            };
+
+            // Act 
+            var proxy = ConvertTo<IHasReadOnlyListOfPersonProperty>(value);
+
+            // Assert
+            Assert.NotNull(proxy);
+
+            var sequence = value.ListProperty.Zip(proxy.ListProperty, (i, j) => Tuple.Create(i, j));
+            foreach (var item in sequence)
+            {
+                Assert.Equal(item.Item1.FirstName, item.Item2.FirstName);
+            }
+        }
+
+        [Fact]
+        public void Adapt_NestedList()
+        {
+            // Arrange
+            var value = new List<IList<IList<Person>>>()
+            {
+                new List<IList<Person>>()
+                {
+                    new List<Person>()
+                    {
+                        new Person() { FirstName = "Billy" },
+                    },
+                },
+            };
+
+            // Act 
+            var proxy = Convert<IList<IList<IList<Person>>>, IReadOnlyList<IReadOnlyList<IReadOnlyList<IPerson>>>>(value);
+
+            // Assert
+            Assert.NotNull(proxy);
+            Assert.Equal(1, proxy[0][0].Count);
+            Assert.Equal("Billy", proxy[0][0][0].FirstName);
+        }
+
         private object ConvertTo(object value, Type type)
         {
             var cache = new ProxyTypeCache();
@@ -231,6 +533,47 @@ namespace Microsoft.Framework.Notification.Internal
             var proxy = Activator.CreateInstance(proxyType, value);
 
             return Assert.IsAssignableFrom<T>(proxy);
+        }
+
+        private U Convert<T, U>(object value)
+        {
+            var cache = new ProxyTypeCache();
+            var proxyType = ProxyTypeEmitter.GetProxyType(cache, typeof(U), typeof(T));
+
+            Assert.NotNull(proxyType);
+            var proxy = Activator.CreateInstance(proxyType, value);
+
+            return Assert.IsAssignableFrom<U>(proxy);
+        }
+
+        public interface IHasReadOnlyListProperty
+        {
+            IReadOnlyList<string> ListProperty { get; }
+        }
+
+        public class HasListProperty
+        {
+            public IList<string> ListProperty { get; set; }
+        }
+
+        public class HasArrayProperty
+        {
+            public string[] ListProperty { get; set; }
+        }
+
+        public class HasReadOnlyListProperty
+        {
+            public IReadOnlyList<string> ListProperty { get; set; }
+        }
+
+        public interface IHasReadOnlyListOfPersonProperty
+        {
+            IReadOnlyList<IPerson> ListProperty { get; }
+        }
+
+        public class HasListOfPersonProperty
+        {
+            public IList<Person> ListProperty { get; set; }
         }
 
         public interface IPrivateGetter


### PR DESCRIPTION
This change adds the ability to generate a proxy type which can expose an
IList<T> as an IReadOnlyList<U> - where the conversion from T -> is via a
second proxy.

We may need to support for additional collection types (IEnumerable,
IDictionary) in the future. This change should get the codebase to a point
where we're able to start using it.