### PR TITLE
Change portable target to dotnet

### DIFF
--- a/src/Microsoft.Framework.Notification/Internal/ProxyAssembly.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyAssembly.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET45 || DNX451 || DNXCORE50
-
 using System;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -50,5 +48,3 @@ namespace Microsoft.Framework.Notification.Internal
 
     }
 }
-
-#endif

--- a/src/Microsoft.Framework.Notification/Internal/ProxyBase.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyBase.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET45 || DNX451 || DNXCORE50
-
 using System;
 
 namespace Microsoft.Framework.Notification.Internal
@@ -24,4 +22,3 @@ namespace Microsoft.Framework.Notification.Internal
     }
 }
 
-#endif

--- a/src/Microsoft.Framework.Notification/Internal/ProxyBaseOfT.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyBaseOfT.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET45 || DNX451 || DNXCORE50
-
 using Microsoft.Framework.Internal;
 
 namespace Microsoft.Framework.Notification.Internal
@@ -36,4 +34,3 @@ namespace Microsoft.Framework.Notification.Internal
     }
 }
 
-#endif

--- a/src/Microsoft.Framework.Notification/Internal/ProxyEnumerable.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyEnumerable.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET45 || DNX451 || DNXCORE50
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -90,5 +88,3 @@ namespace Microsoft.Framework.Notification.Internal
         }
     }
 }
-
-#endif

--- a/src/Microsoft.Framework.Notification/Internal/ProxyList.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyList.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET45 || DNX451 || DNXCORE50
-
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -68,5 +66,3 @@ namespace Microsoft.Framework.Notification.Internal
         }
     }
 }
-
-#endif

--- a/src/Microsoft.Framework.Notification/Internal/ProxyMethodEmitter.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyMethodEmitter.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET45 || DNX451 || DNXCORE50
-
 using System;
 using System.Linq;
 using System.Reflection;
@@ -142,5 +140,3 @@ namespace Microsoft.Framework.Notification.Internal
         }
     }
 }
-
-#endif

--- a/src/Microsoft.Framework.Notification/Internal/ProxyTypeCache.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyTypeCache.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET45 || DNX451 || DNXCORE50
-
 using System;
 using System.Collections.Concurrent;
 
@@ -12,5 +10,3 @@ namespace Microsoft.Framework.Notification.Internal
     {
     }
 }
-
-#endif

--- a/src/Microsoft.Framework.Notification/Internal/ProxyTypeCacheResult.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyTypeCacheResult.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET45 || DNX451 || DNXCORE50
-
 using System;
 using System.Reflection;
 
@@ -43,4 +41,3 @@ namespace Microsoft.Framework.Notification.Internal
         public Type Type { get; private set; }
     }
 }
-#endif

--- a/src/Microsoft.Framework.Notification/Internal/ProxyTypeEmitter.cs
+++ b/src/Microsoft.Framework.Notification/Internal/ProxyTypeEmitter.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET45 || DNX451 || DNXCORE50
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -440,4 +438,3 @@ namespace Microsoft.Framework.Notification.Internal
         }
     }
 }
-#endif

--- a/src/Microsoft.Framework.Notification/NotifierMethodAdapter.cs
+++ b/src/Microsoft.Framework.Notification/NotifierMethodAdapter.cs
@@ -10,63 +10,7 @@ namespace Microsoft.Framework.Notification
     {
         public Func<object, object, bool> Adapt(MethodInfo method, Type inputType)
         {
-#if NET45 || DNX451 || DNXCORE50
             return Internal.ProxyMethodEmitter.CreateProxyMethod(method, inputType);
-#else
-            return CreateReflectionAdapter(method, inputType);
-#endif
         }
-
-#if !NET45 && !DNX451 && !DNXCORE50
-        private Func<object, object, bool> CreateReflectionAdapter(MethodInfo method, Type inputType)
-        {
-            var parameters = method.GetParameters();
-
-            var mappings = new PropertyInfo[parameters.Length];
-
-            var inputTypeInfo = inputType.GetTypeInfo();
-            for (var i = 0; i < parameters.Length; i++)
-            {
-                var property = inputTypeInfo.GetDeclaredProperty(parameters[i].Name);
-                if (property == null)
-                {
-                    continue;
-                }
-                else
-                {
-                    mappings[i] = property;
-                }
-            }
-
-            return (instance, input) =>
-            {
-                if (input.GetType() != inputType)
-                {
-                    return false;
-                }
-
-                var arguments = new object[mappings.Length];
-                for (var j = 0; j < mappings.Length; j++)
-                {
-                    var mapping = mappings[j];
-                    var parameter = parameters[j];
-                    if (mapping == null)
-                    {
-                        if (parameter.ParameterType.GetTypeInfo().IsValueType)
-                        {
-                            arguments[j] = Activator.CreateInstance(parameter.ParameterType);
-                        }
-                    }
-                    else if (parameter.ParameterType.IsAssignableFrom(mapping.PropertyType))
-                    {
-                        arguments[j] = mapping.GetValue(input);
-                    }
-                }
-
-                method.Invoke(instance, arguments);
-                return true;
-            };
-        }
-#endif
     }
 }

--- a/src/Microsoft.Framework.Notification/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.Framework.Notification/ServiceCollectionExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-#if NET45 || DNX451 || DNXCORE50
-
 using Microsoft.Framework.Notification;
 
 namespace Microsoft.Framework.DependencyInjection
@@ -17,5 +15,3 @@ namespace Microsoft.Framework.DependencyInjection
         }
     }
 }
-
-#endif

--- a/src/Microsoft.Framework.Notification/project.json
+++ b/src/Microsoft.Framework.Notification/project.json
@@ -23,38 +23,24 @@
                 "System.Collections.Concurrent": ""
             }
         },
-        "dnxcore50": {
+        "dotnet": {
             "dependencies": {
+                "System.ComponentModel": "4.0.0-beta-*",
                 "System.Collections.Concurrent": "4.0.10-beta-*",
                 "System.Collections": "4.0.10-beta-*",
                 "System.Diagnostics.Debug": "4.0.10-beta-*",
                 "System.Globalization": "4.0.10-beta-*",
                 "System.Linq": "4.0.0-beta-*",
+                "System.Linq.Expressions": "4.0.10-beta-*",
                 "System.Threading": "4.0.10-beta-*",
+                "System.Reflection": "4.0.10-beta-*",   
                 "System.Reflection.Emit": "4.0.0-beta-*",
                 "System.Reflection.Emit.Lightweight": "4.0.0-beta-*",
                 "System.Reflection.Extensions": "4.0.0-beta-*",
                 "System.Reflection.TypeExtensions": "4.0.0-beta-*",
                 "System.Resources.ResourceManager": "4.0.0-beta-*",
-                "System.Runtime.Extensions": "4.0.10-beta-*"
-            }
-        },
-        ".NETPortable,Version=v4.6,Profile=Profile151": {
-            "dependencies": {
                 "System.Runtime": "4.0.20-beta-*",
-                "System.Reflection.TypeExtensions": "4.0.0-beta-*"
-            },
-            "frameworkAssemblies": {
-                "System.Collections": "",
-                "System.Collections.Concurrent": "",
-                "System.Diagnostics.Debug": "",
-                "System.Globalization": "",
-                "System.Reflection": "",
-                "System.Reflection.Extensions": "",
-                "System.Resources.ResourceManager": "",
-                "System.Runtime.Extensions": "",
-                "System.Linq": "",
-                "System.Threading": ""
+                "System.Runtime.Extensions": "4.0.10-beta-*"
             }
         }
     }

--- a/test/Microsoft.Framework.Notification.Test/NotifierMethodAdapterTest.cs
+++ b/test/Microsoft.Framework.Notification.Test/NotifierMethodAdapterTest.cs
@@ -99,8 +99,6 @@ namespace Microsoft.Framework.Notification
             Assert.Null(listener.Name);
         }
 
-#if NET45 || DNX451 || DNXCORE50
-
         [Fact]
         public void Adapt_SplatsParameters_WithProxy()
         {
@@ -119,8 +117,6 @@ namespace Microsoft.Framework.Notification
             Assert.Equal(17, listener.Id);
             Assert.Equal("Bill", listener.Name);
         }
-
-#endif
 
         private MethodInfo GetMethodInfo<T>(Expression<Action<T>> expression)
         {
@@ -148,8 +144,6 @@ namespace Microsoft.Framework.Notification
             }
         }
 
-#if NET45 || DNX451 || DNXCORE50
-
         private class Listener3
         {
             public int Id { get; set; } = 5;
@@ -172,8 +166,6 @@ namespace Microsoft.Framework.Notification
         {
             string Name { get; }
         }
-
-#endif
 
     }
 }


### PR DESCRIPTION
@rynowak 

`.NETPlatform/dotnet` is the new target framework name for new world. UWP application can use a `dotnet` package. If that's the reason why `portable` library was originally added to this project.

I'll merge this change shortly so as to unblock the build.