### PR TITLE
Use IProxyFactory in generated method stubs

### DIFF
--- a/src/Microsoft.Extensions.DiagnosticAdapter/Internal/ProxyTypeEmitter.cs
+++ b/src/Microsoft.Extensions.DiagnosticAdapter/Internal/ProxyTypeEmitter.cs
@@ -167,7 +167,11 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
             var propertyMappings = new List<KeyValuePair<PropertyInfo, PropertyInfo>>();
 
             var sourceProperties = sourceType.GetRuntimeProperties();
-            foreach (var targetProperty in targetType.GetRuntimeProperties())
+            var targetProperties = targetType
+                .GetInterfaces()
+                .SelectMany(i => i.GetRuntimeProperties())
+                .Concat(targetType.GetRuntimeProperties());
+            foreach (var targetProperty in targetProperties)
             {
                 if (!targetProperty.CanRead)
                 {

--- a/src/Microsoft.Extensions.DiagnosticAdapter/ProxyDiagnosticSourceMethodAdapter.cs
+++ b/src/Microsoft.Extensions.DiagnosticAdapter/ProxyDiagnosticSourceMethodAdapter.cs
@@ -3,14 +3,19 @@
 
 using System;
 using System.Reflection;
+using Microsoft.Extensions.DiagnosticAdapter.Infrastructure;
+using Microsoft.Extensions.DiagnosticAdapter.Internal;
 
 namespace Microsoft.Extensions.DiagnosticAdapter
 {
     public class ProxyDiagnosticSourceMethodAdapter : IDiagnosticSourceMethodAdapter
     {
+        private readonly IProxyFactory _factory = new ProxyFactory();
+
         public Func<object, object, bool> Adapt(MethodInfo method, Type inputType)
         {
-            return Internal.ProxyMethodEmitter.CreateProxyMethod(method, inputType);
+            var proxyMethod = ProxyMethodEmitter.CreateProxyMethod(method, inputType);
+            return (listener, data) => proxyMethod(listener, data, _factory);
         }
     }
 }

--- a/test/Microsoft.Extensions.DiagnosticAdapter.Test/Microsoft.Extensions.DiagnosticAdapter.Test.xproj
+++ b/test/Microsoft.Extensions.DiagnosticAdapter.Test/Microsoft.Extensions.DiagnosticAdapter.Test.xproj
@@ -11,9 +11,11 @@
     <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
     <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
   </PropertyGroup>
-
   <PropertyGroup>
     <SchemaVersion>2.0</SchemaVersion>
   </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
   <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/test/Microsoft.Extensions.DiagnosticAdapter.Test/ProxyDiagnosticSourceMethodAdapterTest.cs
+++ b/test/Microsoft.Extensions.DiagnosticAdapter.Test/ProxyDiagnosticSourceMethodAdapterTest.cs
@@ -8,7 +8,7 @@ using Xunit;
 
 namespace Microsoft.Extensions.DiagnosticAdapter
 {
-    public class ProxyTDiagnosticSourceMethodAdapterTest
+    public class ProxyDiagnosticSourceMethodAdapterTest
     {
         [Fact]
         public void Adapt_Throws_ForSameNamedPropertiesWithDifferentCasing()


### PR DESCRIPTION
This change will fix null-refs from inside of the generated data->method
adapters. This also now uses the runtime type for proxy generation.

Note that we also need to improve the code generation for generated
proxies and the built in collection adapters to be truly nullsafe.