### PR TITLE
Don't reference facades in NuSpec

### DIFF
--- a/src/Microsoft.Extensions.DiagnosticAdapter/project.json
+++ b/src/Microsoft.Extensions.DiagnosticAdapter/project.json
@@ -19,9 +19,7 @@
   "frameworks": {
     "net451": {
       "frameworkAssemblies": {
-        "System.Collections.Concurrent": "",
-        "System.Linq": "",
-        "System.Runtime": ""
+        "System.Runtime": { "type": "build" }
       }
     },
     "netstandard1.3": {


### PR DESCRIPTION
These can be removed entirely after dotnet/cli#164