### PR TITLE
Target .NET Standard 2.0

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -16,8 +16,8 @@
     <PackageReference Include="Internal.AspNetCore.Sdk" Version="$(InternalAspNetCoreSdkVersion)" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework' AND '$(OutputType)'=='library'">
-    <PackageReference Include="NETStandard.Library" Version="$(BundledNETStandardPackageVersion)" />
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'">
+    <PackageReference Include="NETStandard.Library.NETFramework" Version="$(NETStandardLibraryNETFrameworkVersion)" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
     <AspNetCoreVersion>2.0.0-*</AspNetCoreVersion>
-    <CoreFxVersion>4.3.0</CoreFxVersion>
+    <CoreFxVersion>4.4.0-*</CoreFxVersion>
     <InternalAspNetCoreSdkVersion>2.1.0-*</InternalAspNetCoreSdkVersion>
-    <NETStandardImplicitPackageVersion>$(BundledNETStandardPackageVersion)</NETStandardImplicitPackageVersion>
+    <NETStandardLibraryNETFrameworkVersion>2.0.0-*</NETStandardLibraryNETFrameworkVersion>
     <RuntimeFrameworkVersion Condition="'$(TargetFramework)'=='netcoreapp2.0'">2.0.0-*</RuntimeFrameworkVersion>
     <TestSdkVersion>15.3.0-*</TestSdkVersion>
     <XunitVersion>2.3.0-beta2-*</XunitVersion>

--- a/src/Microsoft.Extensions.DiagnosticAdapter/DiagnosticListenerExtensions.cs
+++ b/src/Microsoft.Extensions.DiagnosticAdapter/DiagnosticListenerExtensions.cs
@@ -10,7 +10,7 @@ namespace System.Diagnostics
         public static IDisposable SubscribeWithAdapter(this DiagnosticListener diagnostic, object target)
         {
             var adapter = new DiagnosticSourceAdapter(target);
-            return diagnostic.Subscribe(adapter, adapter.IsEnabled);
+            return diagnostic.Subscribe(adapter, s => adapter.IsEnabled(s));
         }
 
         public static IDisposable SubscribeWithAdapter(
@@ -19,7 +19,7 @@ namespace System.Diagnostics
             Func<string, bool> isEnabled)
         {
             var adapter = new DiagnosticSourceAdapter(target, isEnabled);
-            return diagnostic.Subscribe(adapter, adapter.IsEnabled);
+            return diagnostic.Subscribe(adapter, s => adapter.IsEnabled(s));
         }
 
         public static IDisposable SubscribeWithAdapter(
@@ -28,7 +28,7 @@ namespace System.Diagnostics
             Func<string, object, object, bool> isEnabled)
         {
             var adapter = new DiagnosticSourceAdapter(target, isEnabled);
-            return diagnostic.Subscribe(adapter, adapter.IsEnabled);
+            return diagnostic.Subscribe(adapter, s => adapter.IsEnabled(s));
         }
     }
 }

--- a/src/Microsoft.Extensions.DiagnosticAdapter/Internal/ProxyAssembly.cs
+++ b/src/Microsoft.Extensions.DiagnosticAdapter/Internal/ProxyAssembly.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if NETCOREAPP2_0 || NET461
 using System;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -50,3 +51,7 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
 #endif
     }
 }
+#elif NETSTANDARD2_0
+#else
+#error Target frameworks should be updated
+#endif

--- a/src/Microsoft.Extensions.DiagnosticAdapter/Internal/ProxyFactory.cs
+++ b/src/Microsoft.Extensions.DiagnosticAdapter/Internal/ProxyFactory.cs
@@ -22,8 +22,14 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
                 return (TProxy)obj;
             }
 
+#if NETCOREAPP2_0 || NET461
             var type = ProxyTypeEmitter.GetProxyType(_cache, typeof(TProxy), obj.GetType());
             return (TProxy)Activator.CreateInstance(type, obj);
+#elif NETSTANDARD2_0
+            throw new PlatformNotSupportedException("Cannot create a proxy type on this platform");
+#else
+#error Target frameworks should be updated
+#endif
         }
     }
 }

--- a/src/Microsoft.Extensions.DiagnosticAdapter/Internal/ProxyMethodEmitter.cs
+++ b/src/Microsoft.Extensions.DiagnosticAdapter/Internal/ProxyMethodEmitter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if NETCOREAPP2_0 || NET461
 using System;
 using System.Linq;
 using System.Reflection;
@@ -20,13 +21,13 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
 
         private static readonly AssemblyBuilder AssemblyBuilder;
         private static readonly ModuleBuilder ModuleBuilder;
-        
+
         static ProxyMethodEmitter()
         {
             var name = new AssemblyName("Microsoft.Extensions.DiagnosticAdapter.ProxyMethodAssembly");
             AssemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(name, AssemblyBuilderAccess.RunAndSave);
             ModuleBuilder = AssemblyBuilder.DefineDynamicModule(name.Name + ".dll");
-        } 
+        }
 #endif
 
         private static readonly MethodInfo ProxyFactoryGenericMethod =
@@ -210,9 +211,9 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
             var typeBuilder = ModuleBuilder.DefineType(typeName, TypeAttributes.Abstract);
             var methodBuilder = typeBuilder.DefineMethod(
                 "Proxy",
-                MethodAttributes.Public, 
-                CallingConventions.Standard, 
-                returnType: typeof(bool), 
+                MethodAttributes.Public,
+                CallingConventions.Standard,
+                returnType: typeof(bool),
                 parameterTypes: new Type[] { typeof(object), typeof(object), typeof(IProxyFactory) });
 
             var il = methodBuilder.GetILGenerator();
@@ -231,3 +232,7 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
 #endif
     }
 }
+#elif NETSTANDARD2_0
+#else
+#error Target frameworks should be updated
+#endif

--- a/src/Microsoft.Extensions.DiagnosticAdapter/Internal/ProxyTypeEmitter.cs
+++ b/src/Microsoft.Extensions.DiagnosticAdapter/Internal/ProxyTypeEmitter.cs
@@ -1,6 +1,7 @@
 // Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+#if NETCOREAPP2_0 || NET461
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -116,7 +117,7 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
 
             if (targetType == sourceType || targetType.GetTypeInfo().IsAssignableFrom(sourceType.GetTypeInfo()))
             {
-                // If we find a trivial conversion, then that will work. 
+                // If we find a trivial conversion, then that will work.
                 return true;
             }
 
@@ -128,7 +129,7 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
                 return false;
             }
 
-            // This is a combination we haven't seen before, and it *might* support proxy generation, so let's 
+            // This is a combination we haven't seen before, and it *might* support proxy generation, so let's
             // start trying.
             context.Visited.Add(key, verificationResult);
 
@@ -154,7 +155,7 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
                     VerificationResult elementResult;
                     context.Visited.TryGetValue(elementKey, out elementResult);
 
-                    var proxyType = elementResult?.Type?.GetTypeInfo() ?? (TypeInfo)elementResult?.TypeBuilder;
+                    var proxyType = elementResult?.Type?.GetTypeInfo() ?? elementResult?.TypeBuilder as Type;
                     if (proxyType == null)
                     {
                         // No proxy needed for elements.
@@ -164,7 +165,7 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
                     else
                     {
                         // We need to proxy each of the elements. Let's generate a type.
-                        GenerateProxyTypeForList(elementKey.Item1, elementKey.Item2, proxyType.AsType(), verificationResult);
+                        GenerateProxyTypeForList(elementKey.Item1, elementKey.Item2, proxyType, verificationResult);
                     }
 
                     return true;
@@ -212,7 +213,7 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
                     return false;
                 }
 
-                // To allow for flexible versioning, we want to allow missing properties in the source. 
+                // To allow for flexible versioning, we want to allow missing properties in the source.
                 //
                 // For now we'll just store null, and later generate a stub getter that returns default(T).
                 var sourceProperty = sourceProperties.Where(p => p.Name == targetProperty.Name).FirstOrDefault();
@@ -492,3 +493,7 @@ namespace Microsoft.Extensions.DiagnosticAdapter.Internal
         }
     }
 }
+#elif NETSTANDARD2_0
+#else
+#error Target frameworks should be updated
+#endif

--- a/src/Microsoft.Extensions.DiagnosticAdapter/Microsoft.Extensions.DiagnosticAdapter.csproj
+++ b/src/Microsoft.Extensions.DiagnosticAdapter/Microsoft.Extensions.DiagnosticAdapter.csproj
@@ -4,17 +4,14 @@
 
   <PropertyGroup>
     <Description>Microsoft extension adapter feature to extend DiagnosticListener. Contains extension methods that extend System.Diagnostics.DiagnosticListener, and enables duck-typing based event handling by using dynamically generated proxy types.</Description>
-    <TargetFramework>netstandard1.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.0;net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>diagnosticadapter;diagnosticlistener;diagnostics</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.ComponentModel" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(CoreFxVersion)" />
-    <PackageReference Include="System.Reflection.Emit" Version="$(CoreFxVersion)" />
-    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="$(CoreFxVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.Extensions.DiagnosticAdapter/ProxyDiagnosticSourceMethodAdapter.cs
+++ b/src/Microsoft.Extensions.DiagnosticAdapter/ProxyDiagnosticSourceMethodAdapter.cs
@@ -14,8 +14,14 @@ namespace Microsoft.Extensions.DiagnosticAdapter
 
         public Func<object, object, bool> Adapt(MethodInfo method, Type inputType)
         {
+#if NETCOREAPP2_0 || NET461
             var proxyMethod = ProxyMethodEmitter.CreateProxyMethod(method, inputType);
             return (listener, data) => proxyMethod(listener, data, _factory);
+#elif NETSTANDARD2_0
+            throw new PlatformNotSupportedException("This platform does not support creating proxy types and methods");
+#else
+#error Target frameworks should be updated
+#endif
         }
     }
 }

--- a/test/Microsoft.Extensions.DiagnosticAdapter.Test/Microsoft.Extensions.DiagnosticAdapter.Test.csproj
+++ b/test/Microsoft.Extensions.DiagnosticAdapter.Test/Microsoft.Extensions.DiagnosticAdapter.Test.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
Part of https://github.com/aspnet/Home/issues/2045

Notable changes:
 - Target `netstandard2.0`, `netcoreapp2.0`, and `net461`
 - The `netstandard2.0` throws `PlatformNotSupportedException` for the following public API
   - `ProxyDiagnosticSourceMethodAdapter.Adapt`.
 - A few .Internal types will throw `PlatformNotSupportedExcpetion` or will not be available at all in the ns2.0 assembly when their public surface depended on System.Reflection.Emit types


Background: System.Reflection.Emit was (perhaps mistakenly) part of .NET Standard 1.x, but was removed from 2.0. These APIs are only available when targeting .NET Core 2.0 and .NET Framework 4.6.1 directly.