### PR TITLE
Remove dependency on DI abstractions

### DIFF
--- a/src/Microsoft.Extensions.DiagnosticAdapter/Microsoft.Extensions.DiagnosticAdapter.csproj
+++ b/src/Microsoft.Extensions.DiagnosticAdapter/Microsoft.Extensions.DiagnosticAdapter.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(AspNetCoreVersion)" />
     <PackageReference Include="System.ComponentModel" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(CoreFxVersion)" />
     <PackageReference Include="System.Reflection.Emit" Version="$(CoreFxVersion)" />


### PR DESCRIPTION
Regardless of what we decide in #70, it appears this dependency is completely unnecessary.

